### PR TITLE
Fallback to media_folder for public_folder

### DIFF
--- a/src/get-config.js
+++ b/src/get-config.js
@@ -12,9 +12,8 @@ module.exports = async function({ cmsConfig = `/static/admin/config.yml` }){
 		console.error(`Missing media_folder in Netlify CMS config`)
 		process.exit(1)
 	}
-	if(!public_folder ){
-		console.error(`Missing public_folder in Netlify CMS config`)
-		process.exit(1)
+	if (!public_folder) {
+		public_folder = media_folder
 	}
 	obj = {
 		mediaPath: media_folder,


### PR DESCRIPTION
As per the [NetlifyCMS docs](https://www.netlifycms.org/docs/configuration-options/#media-and-public-folders), the public_folder defaults to the media_folder.

This should be respected by this plugin.