### PR TITLE
Use RegEx to test for JSON nodes

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -55,12 +55,9 @@ exports.onCreateNode = async ({ node, getNode }, options) => {
 		if(typeof node.frontmatter === `object`) {
 			await walkObject(node.frontmatter, iteratee, commonProps)
 		}
-	} else if (/^\w+Yaml$/.test(node.internal.type) ) {
+	} else if (/^\w+(Yaml|Json)$/.test(node.internal.type) ) {
 		nodeAbsPath = getNode(node.parent).absolutePath
 
 		await walkObject(node, iteratee, commonProps)
-	} else if (node.internal.type === "ContentJson") {
-    nodeAbsPath = getNode(node.parent).absolutePath;
-    await walkObject(node, iteratee, commonProps);
-  }
+	}
 }


### PR DESCRIPTION
In #7, support for JSON was added, however this would only work for JSON files within a folder named `content`. To allow this plugin to work with all JSON files from Netlify CMS, I reverted the changes made in #7 and modified the RegEx for YAML which was added in #4.