### PR TITLE
Make returned relative path platform agnostic

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "read-yaml-promise": "^1.0.2",
+    "slash": "^3.0.0",
     "unist-util-select": "^1.5.0"
   }
 }

--- a/src/make-relative.js
+++ b/src/make-relative.js
@@ -1,5 +1,6 @@
 const { relative, dirname } = require(`path`)
 const getConfig = require(`./get-config`)
+const slash = require(`slash`)
 
 const cwd = process.cwd()
 
@@ -14,5 +15,5 @@ module.exports = async (markdownPath, imagePath, options) => {
 	markdownPath = dirname(markdownPath).replace(`${cwd}/`, ``)
 	imagePath = imagePath.replace(publicPath, mediaPath)
 	const newPath = relative(markdownPath, imagePath)
-	return newPath
+	return slash(newPath)
 }


### PR DESCRIPTION
This fix brings in the [slash](https://github.com/sindresorhus/slash) library to convert Windows backslashes in the returned relative path. 

I still have no idea why this problem didn't emerge for me until gatsby 2.2.0.